### PR TITLE
Removed version tag from docker-compose.yml to fix warning on build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   backend:
     build: ./backend


### PR DESCRIPTION
Warning message that was removed:
time="2025-05-18T15:12:15-04:00" level=warning
msg="C:\\important\\kevinmeixner.com_websites\\kevinmeixner_com_demos\\not_uploaded\\plain-fastapi-react-docker\\docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"

modified:   docker-compose.yml